### PR TITLE
Adjustments from V:2024-12-22 Establish Primary Ambassador Team Assignments

### DIFF
--- a/Ambassador Bylaws/Article2.html
+++ b/Ambassador Bylaws/Article2.html
@@ -230,7 +230,7 @@
       allocation and vesting. The score for any Ambassador that did not provide Submissions will be 0 for
       that period.</li>
     <li>Ambassadors are expected to demonstrate meaningful contribution each month toward the responsibilities
-      of their selected Primary Team, as outlined in Article 3, Section 1(c).</li>
+      of their selected Primary Team, as outlined in Article 3, Section 1.3.</li>
 
 
   </ol>

--- a/Ambassador Bylaws/Article2.html
+++ b/Ambassador Bylaws/Article2.html
@@ -93,7 +93,12 @@
     </li>
     <li>Role Assignment. Ambassadors will be granted roles in relevant communications platforms to allow them to
       speak as Ambassadors in the community.</li>
-    <li>Team Participation. Ambassadors may self-select to participate in any Official or Ad hoc Team.</li>
+    <li>Team Participation. Ambassadors may self-select to participate in any Official or Ad hoc Team and must select a Primary Official Team.
+      <ol>
+        <li>Flexibility in Team Selection. Ambassadors may still participate in additional teams but will be assessed primarily based on their contributions to their selected Primary Team.</li>
+        <li>Primary Team Changes. Primary Team selection can only be modified for the upcoming month by submitting the change to the Sponsor Representative 14 days (UTC) prior to the start of the new month. Once the new month begins, the Primary Team designation for that month will be fixed.</li>
+      </ol>
+    </li>
   </ol>
   <li>Obligations of Ambassadors.</li>
   <ol>
@@ -224,6 +229,10 @@
       publish updated scores and an updated vesting schedule for each Ambassador noting their current
       allocation and vesting. The score for any Ambassador that did not provide Submissions will be 0 for
       that period.</li>
+    <li>Ambassadors are expected to demonstrate meaningful contribution each month toward the responsibilities
+      of their selected Primary Team, as outlined in Article 3, Section 1(c).</li>
+
+
   </ol>
   <li>Removal of Ambassadors. Ambassadors may be removed from the program for failing to fulfill the
     Obligations of Ambassadors or by resignation. Any failure to fulfill the Obligations will be determined


### PR DESCRIPTION
Add adjustments from V:2024-12-22 Establish Primary Ambassador Team Assignments

- Implement Primary Team selection requirement for Ambassadors
- Add team assessment criteria based on Primary Team contributions
- Include process for changing Primary Team designation
- Update Peer Review Process to reference Primary Team responsibilities

https://discord.com/channels/864285291518361610/1318120273899163688/1318120276361482281