### PR TITLE
v: 2025-04-09 Redefine Inadequate Contribution

### DIFF
--- a/Ambassador Bylaws/Article2.html
+++ b/Ambassador Bylaws/Article2.html
@@ -222,9 +222,9 @@
       of the requested peer evaluations on time, or iii) receiving a score of zero on two or more evaluations. If any
       Ambassador or Lead Ambassador incurs a Failure to Participate more than twice in any contiguous 6-month period,
       such person will be automatically terminated from the Program.&nbsp;</li>
-    <li>Inadequate Contribution. Scoring 2 standard deviations below the average for 3 of any rolling
-      6-month period will require the Governance Team to register a Complaint with the Conflict Resolution
-      Team.</li>
+    <li>Inadequate Contribution. Scoring less than 3.0 as the monthly score for 2 or more months of any 
+      rolling 6-month period will automatically refer a Complaint to the Conflict Resolution Team, and the Ambassador's 
+      status will be updated to Inadequate Contribution until resolved by the Conflict Resolution Team.</li>
     <li>Scores, Allocation and Vesting Confirmation. After each Peer Review Process, the Sponsor shall
       publish updated scores and an updated vesting schedule for each Ambassador noting their current
       allocation and vesting. The score for any Ambassador that did not provide Submissions will be 0 for


### PR DESCRIPTION
This PR proposes a modification to the definition of "Inadequate Contribution" in Article 2 of the bylaws.

Currently, the rule states that an inadequate contribution occurs when a member scores 2 standard deviations below the average over any 6-month rolling period, prompting the Governance Team to file a Complaint with the Conflict Resolution Team.

The proposed change aims to simplify and clarify this process. It establishes that scoring less than 3.0 on the monthly score for 2 or more months within any 6-month rolling window will automatically trigger a referral to the Conflict Resolution Team, and the member's status will be updated to "Inadequate Contribution" until resolved.