### PR TITLE
Bylaws change for 20260204 GA vote + identifying paragraphs

### DIFF
--- a/Ambassador Bylaws/Article1.html
+++ b/Ambassador Bylaws/Article1.html
@@ -1,79 +1,85 @@
 <title>Autonomys Network Ambassador Program Bylaws - Article 1</title>
 <h2 id="article1">Article 1. <b>Role of Sponsor</b></h2>
 <ol>
-    <li>Funding. Sponsor has committed up to 1% of the total token supply of the Network to the Program to
-        provide a reward structure for Ambassadors.</li>
+  <li id="seection1">Funding. Sponsor has committed up to 1% of the total token supply of the Network to the Program to
+    provide a reward structure for Ambassadors.</li>
+  <ol>
+    <li id="section1paragraph1">Token Grants. Sponsor shall make available the necessary tokens for Ambassador token
+      grants as outlined in the Ambassador Benefits (https://ambassador.subspace.foundation/benefits) and formalized
+      in each Ambassador Agreement.</li>
+  </ol>
+  <li id="seection2">Ambassador Agreements. These Bylaws form an integral part of each Ambassador Agreement
+    between Sponsor and an Ambassador. If there are conflicts between an
+    Ambassador Agreement and these Bylaws, Sponsor and the relevant Ambassador(s) shall work in good faith to
+    amend the Bylaws through the governance processes herein, and/or amend the Ambassador Agreement to
+    resolve the conflict.</li>
+  <li id="section3">Oversight. Sponsor shall maintain oversight of the Program as defined in this paragraph.</li>
+  <ol>
+    <li id="section3paragraph1">Sponsor Representative. Sponsor shall appoint one representative to provide oversight of
+      the Program at all
+      times.</li>
+    <li id="section3paragraph2">Sponsor Representative Replacement. Sponsor may recall and replace its
+      representative.The Ambassadors may,
+      by a Supermajority Decision, request that the Sponsor replace its representative. Sponsor shall replace its
+      representative within 90 days after receipt of a replacement request unless a subsequent Supermajority
+      Decision of the Ambassadors withdraws the request within 30 days of the original request.</li>
+    <li id="section3paragraph3">Sponsor Veto and Sponsor Consent. These Bylaws, and any Agreements that amend these
+      Bylaws, are effective when consented to by the Sponsor Representative. Sponsor shall consent to Agreements made
+      with a
+      Supermajority Decision unless Sponsor objects for specific reasons below, provided via written response
+      explaining the reason for the Veto, along with suggested modifications that may be taken to obtain support.
+    </li>
     <ol>
-        <li>Token Awards. Sponsor shall make available the necessary tokens to provide for the token grants
-            specified in <a href="./Article2.html#paragraph5">Article 2 Section 5 Rights of Ambassadors</a> and in <a
-                href="./Article2.html#paragraph7">Article 2 Section 7 Rights of Lead Ambassadors</a>.</li>
-        <li>Distribution of Tokens. Tokens that have been earned and vested under the Program may begin
-            distribution to Ambassadors upon the launch of Mainnet Beta. All tokens distributed to Ambassadors under
-            this Program at the beginning of Mainnet Beta will be subject to a 6-month lockup, meaning the tokens will
-            not be transferable until 6 months after the launch of Mainnet Beta. The lockup period is static, so tokens
-            vested and distributed 3 months after Mainnet Beta begins would be locked for a subsequent 3 months. Earned
-            and vested tokens are able to be claimed (after the lockup period) by each Ambassador at any time.</li>
+      <li id="section3paragraph3subparagraph1">Violation Veto. Sponsor may veto an amendment that violates, or is
+        reasonably expected to cause a
+        violation of, the Sponsor’s governing documents or vendor contracts.</li>
+      <li id="section3paragraph3subparagraph2">Risk Veto. Sponsor may veto an amendment that is likely, in the opinion
+        of the Sponsor, to expose the
+        Program or the Network to significant risk, and there are not sufficient mechanisms in place, in the
+        opinion of the Sponsor, to reasonably avoid, control, or compensate for the risk.</li>
     </ol>
-    <li>Ambassador Agreements. The Ambassador agreements are between Sponsor and each Ambassador and implement the
-        Bylaws between the Sponsor and the Ambassador (the “Ambassador Agreement(s)”). If there are conflicts between an
-        Ambassador Agreement and these Bylaws, Sponsor and the relevant Ambassador(s) shall work in good faith to
-        complete amendments to conform with the Bylaws as in effect at the execution of the Agreement.</li>
-    <li>Oversight. Sponsor shall maintain oversight of the Program as defined in this paragraph.&nbsp;</li>
-    <ol>
-        <li>Sponsor Representative. Sponsor shall appoint one representative to provide oversight of the Program at all
-            times.</li>
-        <li>Sponsor Representative Replacement. Sponsor may recall and replace its representative.The Ambassadors may,
-            by a Supermajority Decision, request that the Sponsor replace its representative. Sponsor shall replace its
-            representative within 90 days after receipt of a replacement request unless a subsequent Supermajority
-            Decision of the Ambassadors withdraws the request within 30 days of the original request.</li>
-        <li id="section3paragraph3">Sponsor Veto and Sponsor Consent. These Bylaws, and any Agreements that amend these
-            Bylaws, are effective
-            when consented to by the Sponsor Representative. Sponsor shall consent to Agreements made with a
-            Supermajority Decision unless Sponsor objects for specific reasons below, provided via written response
-            explaining the reason for the Veto, along with suggested modifications that may be taken to obtain support.
-        </li>
-        <ol>
-            <li>Violation Veto. Sponsor may veto an amendment that violates, or is reasonably expected to cause a
-                violation of, the Sponsor’s governing documents or vendor contracts.</li>
-            <li>Risk Veto. Sponsor may veto an amendment that is likely, in the opinion of the Sponsor, to expose the
-                Program or the Network to significant risk, and there are not sufficient mechanisms in place, in the
-                opinion of the Sponsor, to reasonably avoid, control, or compensate for the risk.</li>
-        </ol>
-        <li>Admission of Ambassadors. An Ambassador shall be admitted to the Program upon the signing of an Ambassador
-            Agreement with Sponsor. The agreement shall include the Rights and Obligations specified in these Bylaws.
-            Within thirty days of selection, Sponsor shall conduct its due diligence to determine whether it shall enter
-            into an Agreement with the person recommended for admission. If&nbsp; satisfied, Sponsor shall execute the
-            Ambassador Agreement and notify the designated team responsible for onboarding new Ambassadors (“Onboarding
-            and Growth Team”). If Sponsor declines to enter into an Ambassador Agreement, Sponsor shall communicate
-            directly with the proposed Ambassador and shall inform the Onboarding and Growth Team that Sponsor is
-            denying the admission.</li>
-        <li>Termination of Ambassadors. Upon the resignation of an Ambassador or Lead Ambassador, or the resignation of
-            a Lead Ambassador who will continue to serve as an Ambassador, or receipt of a request to terminate an
-            Ambassador as an outcome of the Conflict Resolution process, Sponsor shall terminate the related Agreements
-            promptly. Sponsor will not unilaterally terminate an Ambassador except in the case of gross misconduct, as
-            determined in Sponsor’s sole discretion, but will use the Conflict Resolution process.</li>
-        <li>Appointment of Lead Ambassadors. Upon notification of the selection of an Ambassador to become a Lead
-            Ambassador, Sponsor shall conduct its due diligence to confirm the Ambassador is in Good Standing and then
-            shall effectuate the additional responsibilities and compensation for a Lead Ambassador. If Sponsor
-            determines the Ambassador is not in Good Standing, Sponsor shall decline the Lead appointment, and instead
-            shall create a Complaint in the Conflict Resolution process.</li>
-        <li>Demotion of Lead Ambassadors. Upon i) the resignation of a Lead Ambassador from the Lead role, ii) a
-            Conflict Resolution determination that a Lead Ambassador be demoted, iii) a notification from the relevant
-            team that they have recalled the Lead Ambassador, Sponsor shall work to amend the Ambassador Agreement (if
-            needed) to remove the Lead role and to stop further compensation attributable to the performance of the Lead
-            Ambassador role.</li>
-    </ol>
-    <li>Termination Rights. At any time after the full vesting and payment of any and all consideration under this
-        Program by Sponsor or its affiliates to each and every Ambassador, Sponsor may, but shall not be required to,
-        terminate this Ambassador Program and shall be free of its obligations hereunder after the expiration or
-        termination of each and every Ambassador Agreement.</li>
-    <li>Messaging and Policies. Sponsor is responsible for setting the general direction and suggested content for
-        marketing and communications messaging, which may be implemented and promulgated by Ambassadors. Sponsor is also
-        responsible for setting policies related to the use of assets, platforms, communications channels, etc. held by
-        Sponsor which may be used, administered, or moderated by Ambassadors.</li>
-    <li>Delegation to Ambassadors. All responsibilities for the oversight and administration of the Program not reserved
-        for Sponsor in this Article shall be held by the Ambassadors in accordance with these Bylaws.</li>
+    <li id="section3paragraph4">Admission of Ambassadors. An Ambassador shall be admitted to the Program upon the
+      signing of an Ambassador
+      Agreement with Sponsor. The agreement shall include the Rights and Obligations specified in these Bylaws.
+      Within thirty days of selection, Sponsor shall conduct its due diligence to determine whether it shall enter
+      into an Agreement with the person recommended for admission. If satisfied, Sponsor shall execute the
+      Ambassador Agreement and notify the designated team responsible for onboarding new Ambassadors (“Onboarding
+      and Growth Team”). If Sponsor declines to enter into an Ambassador Agreement, Sponsor shall communicate
+      directly with the proposed Ambassador and shall inform the Onboarding and Growth Team that Sponsor is
+      denying the admission.</li>
+    <li id="section3paragraph5">Termination of Ambassadors. Upon the resignation of an Ambassador or Lead Ambassador, or
+      the resignation of
+      a Lead Ambassador who will continue to serve as an Ambassador, or receipt of a request to terminate an
+      Ambassador as an outcome of the Conflict Resolution process, Sponsor shall terminate the related Agreements
+      promptly. Sponsor will not unilaterally terminate an Ambassador except in the case of gross misconduct, as
+      determined in Sponsor’s sole discretion, but will use the Conflict Resolution process.</li>
+    <li id="section3paragraph6">Appointment of Lead Ambassadors. Upon notification of the selection of an Ambassador to
+      become a Lead
+      Ambassador, Sponsor shall conduct its due diligence to confirm the Ambassador is in Good Standing and then
+      shall effectuate the additional responsibilities and compensation for a Lead Ambassador. If Sponsor
+      determines the Ambassador is not in Good Standing, Sponsor shall decline the Lead appointment, and instead
+      shall create a Complaint in the Conflict Resolution process.</li>
+    <li id="section3paragraph7">Demotion of Lead Ambassadors. Upon i) the resignation of a Lead Ambassador from the Lead
+      role, ii) a
+      Conflict Resolution determination that a Lead Ambassador be demoted, iii) a notification from the relevant
+      team that they have recalled the Lead Ambassador, Sponsor shall work to amend the Ambassador Agreement (if
+      needed) to remove the Lead role and to stop further compensation attributable to the performance of the Lead
+      Ambassador role.</li>
+  </ol>
+  <li id="seection4">Termination Rights. At any time after the full vesting and payment of any and all consideration
+    under this
+    Program by Sponsor or its affiliates to each and every Ambassador, Sponsor may, but shall not be required to,
+    terminate this Ambassador Program and shall be free of its obligations hereunder after the expiration or
+    termination of each and every Ambassador Agreement.</li>
+  <li id="seection5">Messaging and Policies. Sponsor is responsible for setting the general direction and suggested
+    content for
+    marketing and communications messaging, which may be implemented and promulgated by Ambassadors. Sponsor is also
+    responsible for setting policies related to the use of assets, platforms, communications channels, etc. held by
+    Sponsor which may be used, administered, or moderated by Ambassadors.</li>
+  <li id="seection6">Delegation to Ambassadors. All responsibilities for the oversight and administration of the Program
+    not reserved
+    for Sponsor in this Article shall be held by the Ambassadors in accordance with these Bylaws.</li>
 </ol>
 
 <a href="./Preamble.html"><- Preamble</a>
-        <a href="./Article2.html">Article 2 -></a>
+    <a href="./Article2.html">Article 2 -></a>

--- a/Ambassador Bylaws/Article1.html
+++ b/Ambassador Bylaws/Article1.html
@@ -1,14 +1,14 @@
 <title>Autonomys Network Ambassador Program Bylaws - Article 1</title>
 <h2 id="article1">Article 1. <b>Role of Sponsor</b></h2>
 <ol>
-  <li id="seection1">Funding. Sponsor has committed up to 1% of the total token supply of the Network to the Program to
+  <li id="section1">Funding. Sponsor has committed up to 1% of the total token supply of the Network to the Program to
     provide a reward structure for Ambassadors.</li>
   <ol>
     <li id="section1paragraph1">Token Grants. Sponsor shall make available the necessary tokens for Ambassador token
       grants as outlined in the Ambassador Benefits (https://ambassador.subspace.foundation/benefits) and formalized
       in each Ambassador Agreement.</li>
   </ol>
-  <li id="seection2">Ambassador Agreements. These Bylaws form an integral part of each Ambassador Agreement
+  <li id="section2">Ambassador Agreements. These Bylaws form an integral part of each Ambassador Agreement
     between Sponsor and an Ambassador. If there are conflicts between an
     Ambassador Agreement and these Bylaws, Sponsor and the relevant Ambassador(s) shall work in good faith to
     amend the Bylaws through the governance processes herein, and/or amend the Ambassador Agreement to
@@ -19,7 +19,7 @@
       the Program at all
       times.</li>
     <li id="section3paragraph2">Sponsor Representative Replacement. Sponsor may recall and replace its
-      representative.The Ambassadors may,
+      representative. The Ambassadors may,
       by a Supermajority Decision, request that the Sponsor replace its representative. Sponsor shall replace its
       representative within 90 days after receipt of a replacement request unless a subsequent Supermajority
       Decision of the Ambassadors withdraws the request within 30 days of the original request.</li>
@@ -66,17 +66,17 @@
       needed) to remove the Lead role and to stop further compensation attributable to the performance of the Lead
       Ambassador role.</li>
   </ol>
-  <li id="seection4">Termination Rights. At any time after the full vesting and payment of any and all consideration
+  <li id="section4">Termination Rights. At any time after the full vesting and payment of any and all consideration
     under this
     Program by Sponsor or its affiliates to each and every Ambassador, Sponsor may, but shall not be required to,
     terminate this Ambassador Program and shall be free of its obligations hereunder after the expiration or
     termination of each and every Ambassador Agreement.</li>
-  <li id="seection5">Messaging and Policies. Sponsor is responsible for setting the general direction and suggested
+  <li id="section5">Messaging and Policies. Sponsor is responsible for setting the general direction and suggested
     content for
     marketing and communications messaging, which may be implemented and promulgated by Ambassadors. Sponsor is also
     responsible for setting policies related to the use of assets, platforms, communications channels, etc. held by
     Sponsor which may be used, administered, or moderated by Ambassadors.</li>
-  <li id="seection6">Delegation to Ambassadors. All responsibilities for the oversight and administration of the Program
+  <li id="section6">Delegation to Ambassadors. All responsibilities for the oversight and administration of the Program
     not reserved
     for Sponsor in this Article shall be held by the Ambassadors in accordance with these Bylaws.</li>
 </ol>

--- a/Ambassador Bylaws/Article2.html
+++ b/Ambassador Bylaws/Article2.html
@@ -12,10 +12,7 @@
     Applicants, and Ambassadors will be selected from the Apprentices after an apprenticeship period. The selection
     of Apprentices and Ambassadors shall be according to a transparent procedure defined by the Onboarding and
     Growth Team.</li>
-  <li id="section2">Ambassador Term. Each Ambassador is expected to commit to the role for 4 years. Each ambassador that
-    joined
-    under the Legacy Ambassador Token Grant period is expected to commit to the role for 2 years. Ambassadors may
-    re-apply to serve in subsequent terms after completion of any term.</li>
+  <li id="section2">Removed by GA Vote Feb 4, 2026</li>
   <li id="section3">Selection of Lead Ambassadors. An Ambassador may be selected to be a Lead Ambassador within an
     Official Team by
     a vote of the Ambassadors within the team. Each team must have at least one Lead Ambassador who fluently speaks
@@ -31,74 +28,20 @@
   <li id="section4">Removed by GA Vote June 2025 https://forum.autonomys.xyz/t/remove-ad-hoc-agenda-team/4846</li>
   <li id="section5">Rights of Ambassadors.</li>
   <ol>
-    <li>Legacy Ambassador Token Grant.
-      <strong>Ambassadors joining the program prior to October 2023 receive the Legacy Ambassador Token
-        Grant.</strong>
-      Ambassadors under the Legacy grant will earn up to 0.00526% of the total token supply during their 2-year
-      term. The allocation per quarter shall be: 1) 0.00219%, 2) 0.00076%, 3) 0.00063%, 4) 0.00042%, 5) 0.00036%,
-      6) 0.00032%, 7) 0.00029%, and 8) 0.00029%. Vesting for the Legacy Ambassador Token Grant is over two years,
-      including a 6-month cliff vest of 25%, with the remainder vesting evenly per month over the following 18
-      months. All tokens are subject to a six (6) month lock-up and may not be transferred or withdrawn until 6
-      months after Mainnet Beta commences. Vesting starts on the day the ambassador is admitted to the Program.
-      All allocations under the Legacy Ambassador Token Grant ceased incremental grants or accrual on December 31,
-      2023, and vesting shall continue until the end of the relevant Ambassadors vesting term. All further vesting
-      will cease upon Termination of an Ambassador. Illustrative examples include the following.
-      <ol>
-        <li>If an Ambassador participated in the program for 6 months and a day, then left, they would be
-          allocated
-          .00219% + .00076 = .00295%, and since they left the program after 6 months, they would be 25%
-          vested.
-          After mainnet and the 6-month lockup period per the Distribution of Tokens have passed, the example
-          Ambassador would receive SSC equivalent to 0.0007375% of the token supply.</li>
-        <li>For the same scenario as above, if the Ambassador had joined the program on October 1, 2023, the
-          Ambassador would receive just the first quarter allocation of .00219%, which would still be 25%
-          vested
-          and the Ambassador would instead receive 0.0005475%.</li>
-      </ol>
-    <li>Ambassador Token Grant.
-      <strong>Ambassadors admitted to the program on or after January 1, 2024</strong>
-      will be allocated an award that shall vest over 4 years with a six-month cliff vesting 12.5% and the
-      remaining 87.5% vesting monthly over the remaining 42 months. All tokens are subject to a six (6) month
-      lock-up and may not be transferred or withdrawn until 6 months after Mainnet Beta commences. All further
-      vesting will cease upon Termination of an Ambassador. The size of the award shall be determined based on
-      when the Ambassador is selected as an Apprentice Ambassador, according to the following table. The Award
-      will be granted and vesting will begin on the date that the Apprentice is promoted to Ambassador and
-      admitted as an Ambassador to the Program.
-      <div>
-        <table>
-          <tbody>
-            <tr>
-              <td>Joined During</td>
-              <td>Award Allocation</td>
-            </tr>
-            <tr>
-              <td>Q1-2024</td>
-              <td>0.001250%</td>
-            </tr>
-            <tr>
-              <td>Q2-2024</td>
-              <td>0.0006250%</td>
-            </tr>
-            <tr>
-              <td>Q3-2024</td>
-              <td>0.0003120%</td>
-            </tr>
-            <tr>
-              <td>Q4-2024</td>
-              <td>0.0001560%</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </li>
-    <li>Role Assignment. Ambassadors will be granted roles in relevant communications platforms to allow them to
+    <li id="section5paragraph1">Removed by GA Vote Feb 4, 2026</li>
+    <li id="section5paragraph2">Removed by GA Vote Feb 4, 2026</li>
+    <li id="section5paragraph3">Role Assignment. Ambassadors will be granted roles in relevant communications platforms
+      to allow them to
       speak as Ambassadors in the community.</li>
-    <li>Team Participation. Ambassadors may self-select to participate in any Official or Ad hoc Team and must select a
+    <li id="section5paragraph4">Team Participation. Ambassadors may self-select to participate in any Official or Ad hoc
+      Team and must select a
       Primary Official Team.
       <ol>
-        <li>Flexibility in Team Selection. Ambassadors may still participate in additional teams but will be assessed
+        <li id="section5paragraph4subparagraph1">Flexibility in Team Selection. Ambassadors may still participate in
+          additional teams but will be assessed
           primarily based on their contributions to their selected Primary Team.</li>
-        <li>Primary Team Changes. Primary Team selection can only be modified for the upcoming month by submitting the
+        <li id="section5paragraph4subparagraph2">Primary Team Changes. Primary Team selection can only be modified for
+          the upcoming month by submitting the
           change to the Sponsor Representative 14 days (UTC) prior to the start of the new month. Once the new month
           begins, the Primary Team designation for that month will be fixed.</li>
       </ol>
@@ -106,96 +49,67 @@
   </ol>
   <li id="section6">Obligations of Ambassadors.</li>
   <ol>
-    <li>Working Hours. Ambassadors are required to contribute at least 16 hours of work within 4 calendar weeks
+    <li id="section6paragraph1">Working Hours. Ambassadors are required to contribute at least 16 hours of work within 4
+      calendar weeks
       (4 hours per week is normally expected, with allowances for periods of higher and lower contribution
       spread out over a few weeks to accommodate temporary absence.)</li>
-    <li>Proactive Contribution. Ambassadors are expected to identify their skills such that other Ambassadors
+    <li id="section6paragraph2">Proactive Contribution. Ambassadors are expected to identify their skills such that
+      other Ambassadors
       are aware of their abilities, and are to proactively identify and pursue opportunities to leverage their
       skills to contribute to the Mission of the Program.</li>
-    <li>Active in Community. Ambassadors are expected to be active and visible participants in the community
+    <li id="section6paragraph3">Active in Community. Ambassadors are expected to be active and visible participants in
+      the community
       across the various community spaces and to contribute to an environment that is welcoming,
       permissionless, decentralized, and egalitarian.</li>
-    <li>Governance Participation. Ambassadors must participate in the Peer Review Process, fulfilling their
+    <li id="section6paragraph4">Governance Participation. Ambassadors must participate in the Peer Review Process,
+      fulfilling their
       obligations as both submitter and reviewer. Ambassadors must vote in General Assemblies, and in votes
       presented to the Teams they participate in. Failure by any Ambassador to vote in at least ⅔ of the votes
       before the General Assembly, and at least ⅔ of the votes in their Team(s), is cause for a Complaint
       under the Conflict Resolution Process.</li>
-    <li>Repealed July 12, 2024.</li>
-    <li>Repealed December 9, 2024.</li>
-    <li>Monitored Communications. Ambassadors must monitor announcements and emails from Sponsor and the
+    <li id="section6paragraph5">Repealed July 12, 2024.</li>
+    <li id="section6paragraph6">Repealed December 9, 2024.</li>
+    <li id="section6paragraph7">Monitored Communications. Ambassadors must monitor announcements and emails from Sponsor
+      and the
       Program, and must keep Sponsor advised of an actively monitored email address to be used at all times
       for official communications.</li>
   </ol>
   <li id="section7">Rights of Lead Ambassadors.</li>
   <ol>
-    <li>Legacy Lead Ambassador Token Grant. Lead Ambassadors that were promoted prior to Mainnet Beta earn a
-      pro-rata portion of the lead ambassador token pool for the Testnet network phase based on their active
-      months of participation. The token allocation for the Testnet network for legacy lead ambassadors
-      (“Testnet Lead Ambassador Pool”) is 0.10% of the token supply. The earning of tokens for each Lead
-      Ambassador from the phase token pool will be based on the i) number months the Lead Ambassador has
-      performed in the role, divided by ii) the total number of Lead Ambassador months performed by all Lead
-      Ambassadors, multiplied by iii) the Testnet Lead Ambassador Pool. This allocation vests over 4 years
-      with a 6 month cliff, which is counted from the Lead Ambassador promotion date, vesting 12.5% and the
-      remaining 87.5% vesting over the remaining 42 months. All tokens are subject to a six (6) month lock-up
-      and may not be transferred or withdrawn until 6 months after Mainnet Beta commences.</li>
-    <li>Lead Ambassador Token Grant. Lead Ambassadors promoted to lead on or after the commencement of Mainnet
-      Beta will be allocated an award that shall vest over 4 years with a 6 month cliff vesting 12.5% and the
-      remaining 87.5% vesting over the remaining 42 months. All tokens are subject to a six (6) month lock-up
-      and may not be transferred or withdrawn until 6 months after Mainnet Beta commences. All further vesting
-      will cease in the event of Termination of the Lead Ambassador. The size of the award shall be determined
-      based on when the Ambassador becomes a Lead Ambassador, according to the following table.
-      <div>
-        <table>
-          <tbody>
-            <tr>
-              <td>Joined During</td>
-              <td>Award Allocation</td>
-            </tr>
-            <tr>
-              <td>Q1of Mainnet Beta</td>
-              <td>0.007500%</td>
-            </tr>
-            <tr>
-              <td>Q2 of Mainnet Beta</td>
-              <td>0.003750%</td>
-            </tr>
-            <tr>
-              <td>Q3 of Mainnet Beta</td>
-              <td>0.001875%</td>
-            </tr>
-            <tr>
-              <td>Q4 of Mainnet Beta</td>
-              <td>0.000937%</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </li>
-    <li>Impact on Ambassador Token Grant. While serving in a Lead Ambassador role and earning the Lead Token
+    <li id="section7paragraph1">Removed by GA Vote Feb 4, 2026</li>
+    <li id="section7paragraph2">Removed by GA Vote Feb 4, 2026</li>
+    <li id="section7paragraph3">Impact on Ambassador Token Grant. While serving in a Lead Ambassador role and earning
+      the Lead Token
       Grant, earning of tokens under the relevant Ambassador Token Grant or Legacy Ambassador Token Grant will
       continue, with vesting running in parallel on both the relevant Ambassador Token Grant grant and the
       relevant Lead Ambassador Token Grant.</li>
-    <li>Role Assignment. Lead Ambassadors will be assigned roles in relevant communications platforms to allow
+    <li id="section7paragraph4">Role Assignment. Lead Ambassadors will be assigned roles in relevant communications
+      platforms to allow
       them to speak as Lead Ambassadors in the community.</li>
   </ol>
   <li id="section8">Obligations of Lead Ambassadors.</li>
   <ol>
-    <li>Ambassadors. Lead Ambassadors are Ambassadors and are subject to all of the Obligations of
+    <li id="section8paragraph1">Ambassadors. Lead Ambassadors are Ambassadors and are subject to all of the Obligations
+      of
       Ambassadors, in addition to the incremental obligations here.</li>
-    <li>Working Hours. Lead Ambassadors will be responsible for an additional 24 hours of work within each 4
+    <li id="section8paragraph2">Working Hours. Lead Ambassadors will be responsible for an additional 24 hours of work
+      within each 4
       calendar weeks for a total, including their 16 hours of Ambassador obligation, of 40 hours per
       4-week period, or 10 hours per week on average.</li>
-    <li>Coordinating Team. Lead Ambassadors are expected to coordinate and support the efforts of the Teams
+    <li id="section8paragraph3">Coordinating Team. Lead Ambassadors are expected to coordinate and support the efforts
+      of the Teams
       they participate in. According to the values of Permissionless and Decentralized, Leads are to
       operate with the consent of the Team and are not to manage, assign, or delegate, but are to create
       supporting infrastructure, transparency, and clarity of team purpose that invite and enable the
       contribution of Ambassadors within the team.</li>
-    <li>Coordinating Across Teams. Lead Ambassadors are expected to coordinate the activities and directions
+    <li id="section8paragraph4">Coordinating Across Teams. Lead Ambassadors are expected to coordinate the activities
+      and directions
       the team is taking in areas that may impact or benefit from the support of other teams. As a group,
       Lead Ambassadors are expected to create clarity among the various teams and take care of conflicts,
       overlaps, and gaps across the various purposes, directions, and activities of the teams they lead.
     </li>
-    <li>Ambassador Selection. Lead Ambassadors are expected to ensure that Ambassador Selection is occurring
+    <li id="section8paragraph5">Ambassador Selection. Lead Ambassadors are expected to ensure that Ambassador Selection
+      is occurring
       for openings on their team, providing feedback and encouraging qualified Apprentices to apply, and
       ensuring applications are being reviewed and quality feedback given to applicants.</li>
   </ol>
@@ -211,21 +125,26 @@
     performance
     of Applicant, Apprentice Ambassador, Ambassador and Lead Ambassador Obligations.</li>
   <ol>
-    <li>Peer Groups. The Peer Review Process is conducted within peer groups, where there is a group for
+    <li id="section10paragraph1">Peer Groups. The Peer Review Process is conducted within peer groups, where there is a
+      group for
       Applicants, another group for Apprentices, and a group for Ambassadors which includes Lead
       Ambassadors. If a Peer Group is not larger than 30 people for any review period, it may be combined
       with another Peer Group at the discretion of the Governance Team.</li>
-    <li>Review Period. Each Peer Review Process will evaluate submissions within a calendar month. Each Ambassador
+    <li id="section10paragraph2">Review Period. Each Peer Review Process will evaluate submissions within a calendar
+      month. Each Ambassador
       shall have seven (7) days to provide submissions, and seven (7) days to complete their assigned peer review
       evaluations once distributed.</li>
-    <li>Submissions. Each Ambassador must create transparency by communicating their incremental
+    <li id="section10paragraph3">Submissions. Each Ambassador must create transparency by communicating their
+      incremental
       Contributions each month. The submission must provide sufficient detail to identify the
       Contribution(s), validate that they were made during the relevant month, and enable other peers to
       review and evaluate the Contributions.</li>
-    <li>Evaluations. Each Ambassador in good standing as defined in Article 2, Section 13, at the time
+    <li id="section10paragraph4">Evaluations. Each Ambassador in good standing as defined in Article 2, Section 13, at
+      the time
       evaluation requests are generated must review and score the Contributions of other randomly selected
       peers each month according to this Process.</li>
-    <li>Failure to Participate. Failure to Participate in the Peer Review process means, during any single
+    <li id="section10paragraph5">Failure to Participate. Failure to Participate in the Peer Review process means, during
+      any single
       peer review cycle, any one of the following violations: i) not providing a Submission on time, or
       ii) not returning at least one of the requested peer evaluations on time. For purposes of this section,
       multiple review rounds for a single calendar month of submissions shall be considered one peer review
@@ -233,19 +152,23 @@
       as an evaluator in any supplementary rounds for the relevant month. If any Ambassador or Lead Ambassador
       incurs a Failure to Participate more than twice in any contiguous 6-month period, such person will be
       automatically terminated from the Program.</li>
-    <li>Inadequate Contribution. Scoring Inadequate for the Published Score for 2 or more months of any
+    <li id="section10paragraph6">Inadequate Contribution. Scoring Inadequate for the Published Score for 2 or more
+      months of any
       rolling 6-month period will automatically refer a Complaint to the Conflict Resolution Team, and the
       Ambassador's status will be updated to Inadequate Contribution until resolved by the Conflict
       Resolution Team.</li>
-    <li>Scores. After each Peer Review Process, the Sponsor shall publish updated scores ("Published Score")
+    <li id="section10paragraph7">Scores. After each Peer Review Process, the Sponsor shall publish updated scores
+      ("Published Score")
       which shall be "Adequate" or "Inadequate" for each Ambassador. Submissions are to be evaluated as
       "Adequate" or "Inadequate" by each of up to 3 reviewers in the Peer Review Process. Each "Adequate"
       review will be scored as 3.0, and each "Inadequate" review will be scored as 1.0. The Published Score
       will be determined by the average of the reviews recorded for the period for each Ambassador, with a
       score of less than 2.0 being "Inadequate", and a score of 2.0 or higher being "Adequate".</li>
-    <li>Ambassadors are expected to demonstrate meaningful contribution each month toward the responsibilities
+    <li id="section10paragraph8">Ambassadors are expected to demonstrate meaningful contribution each month toward the
+      responsibilities
       of their selected Primary Team, as outlined in Article 3, Section 1.3.</li>
-    <li>Minimum Review Requirement. Up to three (3) attempts should be made to ensure that each Ambassador is afforded
+    <li id="section10paragraph9">Minimum Review Requirement. Up to three (3) attempts should be made to ensure that each
+      Ambassador is afforded
       three (3) peer reviews per evaluation period. When necessary, up to two (2) supplementary review rounds shall be
       conducted for those Ambassadors' submissions that do not already have three (3) reviews received. If more than
       three (3) reviews are received, only the first three (3) reviews received will be counted.</li>


### PR DESCRIPTION
Per [Bylaws vote Feb 4, 2026](https://forum.autonomys.xyz/t/general-assembly-votes-v-2026-01-22-remove-grant-information-from-bylaws/5019)

Updates 1.1, 1.2, Removes 2.2, 2.5.1, 2.5.2, 2.7.1, 2.7.2. 

Addes identifiers for paragraphs in Articles 1 and 2. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the Feb 4, 2026 GA vote: removes token grant text (Ambassador and Lead) and the Ambassador Term clause, replacing them with “Removed by GA Vote” notes. Adds stable IDs to sections/paragraphs in Articles 1–2, updates Article 1 to reference the Ambassador Benefits page and clarify oversight subsections, and fixes minor typos.

<sup>Written for commit 33b40a05f0ebefa484d016c7bc48b1dfda057fcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

